### PR TITLE
Repository paths for 2p and eye-tracking (acquired with +et package) …

### DIFF
--- a/+dat/paths.m
+++ b/+dat/paths.m
@@ -32,12 +32,12 @@ p.mainRepository = fullfile(server1Name, 'Data2', 'Subjects');
 % Timeline etc
 p.expInfoRepository = p.mainRepository;
 % Repository for storing two photon movies
-p.twoPhotonRepository = fullfile(server4Name, 'Data', '2P');
+p.twoPhotonRepository = p.mainRepository;
 
 % for calcium widefield imaging
 p.widefieldRepository = fullfile(server1Name, 'data', 'GCAMP');
 % Repository for storing eye tracking movies
-p.eyeTrackingRepository = fullfile(server1Name, 'data', 'EyeCamera');
+p.eyeTrackingRepository = p.mainRepository;
 
 % electrophys repositories
 p.lfpRepository = fullfile(server1Name, 'Data', 'Cerebus');


### PR DESCRIPTION
…data are now set to the mainRepositiory

This is currently \\zserver\Data2\Subjects\animalName\dateStr\expNum\yourFilesGoHere
No additional subfolders, all the files will be in that folder, inlcuding all the 2p files
We might (only might) reconsider it at a later stage (as there are usually many 2p files acquired)