### PR TITLE
Patched a bug in ParamEditor: it was failing to update string parameters

### DIFF
--- a/+eui/ParamEditor.m
+++ b/+eui/ParamEditor.m
@@ -218,6 +218,8 @@ classdef ParamEditor < handle
       %  and notifies listeners of the change via the Changed event.
       %
       % See also EUI.FIELDPANEL/ONEDIT, EUI.CONDITIONPANEL/ONEDIT
+      
+      
       if nargin < 4; row = 1; end
       currValue = obj.Parameters.Struct.(name)(:,row);
       if iscell(currValue)
@@ -226,7 +228,11 @@ classdef ParamEditor < handle
         obj.Parameters.Struct.(name){:,row} = newValue;
       else
         newValue = obj.controlValue2Param(currValue, value);
-        obj.Parameters.Struct.(name)(:,row) = newValue;
+        if isstr(newValue)
+           obj.Parameters.Struct.(name) = newValue;
+        else
+            obj.Parameters.Struct.(name)(:,row) = newValue;
+        end
       end
       notify(obj, 'Changed');
     end


### PR DESCRIPTION
String parameters were not behaving correctly, either in mc or in exp.test -- when I tried to edit one, the textbox updated but the underlying param did not, giving the error message shown below. 
I followed up on this a little bit, and found that eui.ParamEditor was making some assumptions about the shape of its variables that weren't met for strings. I hacked a patch, which seems to work with my expDefs -- both string and non-string params are able to be edited. 

It'd be good to test more thoroughly before merging, but I wasn't sure the best way to do that.