### PR TITLE
Added full string support in ParamEditor

### DIFF
--- a/+eui/ParamEditor.m
+++ b/+eui/ParamEditor.m
@@ -217,8 +217,6 @@ classdef ParamEditor < handle
       %  and notifies listeners of the change via the Changed event.
       %
       % See also EUI.FIELDPANEL/ONEDIT, EUI.CONDITIONPANEL/ONEDIT
-      
-      
       if nargin < 4; row = 1; end
       currValue = obj.Parameters.Struct.(name)(:,row);
       if iscell(currValue)
@@ -227,10 +225,10 @@ classdef ParamEditor < handle
         obj.Parameters.Struct.(name){:,row} = newValue;
       else
         newValue = obj.controlValue2Param(currValue, value);
-        if isstr(newValue)
+        if ischar(newValue)
            obj.Parameters.Struct.(name) = newValue;
         else
-            obj.Parameters.Struct.(name)(:,row) = newValue;
+           obj.Parameters.Struct.(name)(:,row) = newValue;
         end
       end
       notify(obj, 'Changed');
@@ -347,13 +345,14 @@ classdef ParamEditor < handle
         case 'logical'
           data = data ~= 0; % If logical do nothing, basically.
         case 'string'
+          data = arrayfun(@(n) strjoin(data(:,n), ', '), 1:size(data,2));
           data = char(data); % Strings not allowed in condition table data
         otherwise
           if isnumeric(data)
             % format numeric types as string number list
             strlist = mapToCell(@num2str, data);
             data = strJoin(strlist, ', ');
-          elseif iscellstr(data)
+          elseif iscellstr(data) %#ok<ISCLSTR>
             data = strJoin(data, ', ');
           end
       end
@@ -374,7 +373,10 @@ classdef ParamEditor < handle
         case 'logical'
           data = data ~= 0;
         case 'char'
-          % do nothing - strings stay as strings
+          % do nothing - chars stay as they are
+        case 'string'
+          if ischar(data); data = strsplit(string(data), {', ' ','}); end
+          data = data(:);
         otherwise
           if isnumeric(currParam)
             % parse string as numeric vector

--- a/tests/ParamEditor_test.m
+++ b/tests/ParamEditor_test.m
@@ -156,8 +156,16 @@ classdef (SharedTestFixtures={matlab.unittest.fixtures.PathFixture(...
       end
       
       % Test string data 
-      % TODO Outcome will change in near future
+      % Strings converted to char arrays due to Table limitations
       testCase.verifyEqual(PE.paramValue2Control("hello"), 'hello')
+      % Strings should be joined across rows
+      testCase.verifyEqual(PE.paramValue2Control(["hello";"hi"]), 'hello, hi')
+      % Verify conditional string parameters are parsed correctly
+      actual = PE.paramValue2Control(["hello","goodbye";"hi","bye"]);
+      testCase.verifyEqual(size(actual), [1 12 2])
+      % Check that string control values are converted correctly
+      actual = PE.controlValue2Param(["hello","hi"],actual(:,:,2));
+      testCase.verifyEqual(["goodbye";"bye"], actual)
 
       % Test numeric data
       testCase.verifyEqual(PE.paramValue2Control(pi), '3.1416')


### PR DESCRIPTION
Response to issue #134.  Now an array of strings behaves the same as numerical arrays, namely...

```
str = [ "A" "B"
        "a" "b" ]
```
... is represented as two trial conditions: `'A, a'` and `'B, b'`.

It seems MATLAB ui tables still can't have strings as data, so the ParamEditor code converts them to char arrays then back again for the underlying parameter structure.  The only current limitation is that your string parameters can't contain commas.  
