### PR TITLE
Fix calibrations

### DIFF
--- a/+hw/+ptb/Window.m
+++ b/+hw/+ptb/Window.m
@@ -479,6 +479,7 @@ classdef Window < hw.Window
       tt = (1:ns)/acqRate;
       
       figure; plot(tt,clock);
+      ylabel('clock signal'); title('Clock');
       
       upCrossings = find(diff( clock > 1 ) ==  1);
       dnCrossings = find(diff( clock > 1 ) == -1);
@@ -490,7 +491,7 @@ classdef Window < hw.Window
       end
       plot( tt, light ); hold on
       xlabel('Time (s)');
-      ylabel('Signal (Volts)');
+      ylabel('Photodiode Signal (Volts)');
       set(gca,'ylim',[0 1.1*max(light)]);
       title(sprintf('In this plot. digital has been delayed by %2.2f ms', delay));
       

--- a/+hw/+ptb/Window.m
+++ b/+hw/+ptb/Window.m
@@ -385,6 +385,28 @@ classdef Window < hw.Window
     end
 
     function [nx, ny] = drawText(obj, text, x, y, colour, vSpacing, wrapAt)
+    % Calls PTB's `DrawFormattedText` to display text to the PTB Window
+    %
+    % Inputs:
+    %   `text`: the text to be displaye
+    %   `x`: a number, in pixels, of the x-position of the left border of 
+    %   the text
+    %   `y`: a number, in pixels, of the y-position of the top border of 
+    %   the text, in pixels
+    %   `colour`: an [r g b] or [r g b a] numeric vector for the color of 
+    %   the text
+    %   `vSpacing`: a number for the spacing between lines of text
+    %   `wrapAt`: a number for the max number of characters in a line of text
+    %
+    % Outputs:
+    %   `nx`: 
+    %   `ny`:
+    %
+    % Examples:
+    % 
+    %
+    %
+    % See also: DrawFormattedText
       if nargin < 7
         wrapAt = [];
       end

--- a/+hw/+ptb/Window.m
+++ b/+hw/+ptb/Window.m
@@ -17,7 +17,7 @@ classdef Window < hw.Window
   properties
     ForegroundColour
     ScreenNum; %Psychtoolbox screen number
-    PxDepth = 32 %the pixel colour depth (bits)
+    PxDepth %the pixel colour depth (bits)
     OpenBounds %default screen region to open window onscreen - empty for full
     SyncBounds %position bounding rectangle of sync region
     %sync region [r g b], or luminance for each consecutive flip (row-wise).
@@ -25,6 +25,7 @@ classdef Window < hw.Window
     SyncColourCycle = [0; 255]
     MonitorId %an identifier for the monitor
     Calibration %Struct containing calibration data
+    PtbHandle = -1 %a handle to the PTB screen window
     PtbVerbosity = 2
     PtbSyncTests
   end
@@ -41,7 +42,6 @@ classdef Window < hw.Window
   end
   
   properties (SetAccess = protected, Transient)
-    PtbHandle = -1 %a handle to the PTB screen window
     RefreshInterval %refresh interval for updating the device
     NextSyncIdx %index into SyncColourCycle for next sync colour
     Invalid = false
@@ -197,9 +197,10 @@ classdef Window < hw.Window
       end
       Screen('Preference', 'SuppressAllWarnings', true);
       % setup screen window
+      %obj.PxDepth = 32;
       obj.PtbHandle = Screen('OpenWindow', obj.ScreenNum, obj.BackgroundColour,...
         obj.OpenBounds, obj.PxDepth);
-      obj.PxDepth = Screen('PixelSize', obj.PtbHandle);
+      %obj.PxDepth = Screen('PixelSize', obj.PtbHandle);
       obj.Bounds = Screen('Rect', obj.PtbHandle);
 
       %first flip will be first sync colour in cycle

--- a/+srv/expServer.m
+++ b/+srv/expServer.m
@@ -14,17 +14,18 @@ function expServer(useTimelineOverride, bgColour)
 %       harware file is used.
 %
 %   Key bindings:
-%     t - Toggle Timeline on and off.  The default state is defined in the
+%     't' - Toggle Timeline on and off.  The default state is defined in the
 %       hardware file but may be overridden as the first input argument.
-%     w - Toggle reward on and off.  This switches the output of the first
+%     'w' - Toggle reward on and off.  This switches the output of the first
 %       DAQ output channel between its 'high' and 'low' state.  The
 %       specific DAQ channel and its default state are set in the hardware
 %       file.
-%     space - Deliver default reward, specified by the DefaultCommand
+%     'space' - Deliver default reward, specified by the DefaultCommand
 %       property in the hardware file.
-%     m - Perform water calibration. 
-%     b - Toggle the background colour between the default and white.
-%     g - Perform gamma correction
+%     'm' - Perform water calibration. 
+%     'g' - Perform gamma correction
+%     'b' - Toggle the background colour between the default and white.
+%     'q' - Quit expServer.
 %     
 %
 % See also MC, io.WSJCommunicator, hw.devices, srv.prepareExp, hw.Timeline
@@ -359,8 +360,8 @@ ShowCursor();
   function calibrateGamma()
     stimWindow = rig.stimWindow;
     DaqDev = rig.daqController.DaqIds;
-    lightIn = 'ai1'; % defaults from hw.psy.Window
-    clockIn = 'ai0';
+    lightIn = 'ai0'; % defaults from hw.ptb.Window
+    clockIn = 'ai1';
     clockOut = 'port1/line0';
     clockOutHint = 'PFI4';
     log(['Please connect photodiode to %s, clockIn to %s and clockOut to '... 
@@ -371,7 +372,7 @@ ShowCursor();
     pause(1);
     saveGamma(stimWindow.Calibration);
     stimWindow.applyCalibration(stimWindow.Calibration);
-    clear('lightIn','clockIn','clockOut','cal');
+    clear('lightIn','clockIn','clockOut','clockOutHint');
     log('Gamma calibration complete');
   end
 

--- a/+srv/expServer.m
+++ b/+srv/expServer.m
@@ -359,6 +359,11 @@ ShowCursor();
 
   function calibrateGamma()
     stimWindow = rig.stimWindow;
+    % move PTB window to background and bring MATLAB command window to front
+    Screen('Preference', 'WindowShieldingLevel', 0);
+    stimWindow.close();
+    stimWindow.open();
+    commandwindow;
     DaqDev = rig.daqController.DaqIds;
     lightIn = 'ai0'; % defaults from hw.ptb.Window
     clockIn = 'ai1';
@@ -374,7 +379,10 @@ ShowCursor();
     stimWindow.applyCalibration(stimWindow.Calibration);
     clear('lightIn','clockIn','clockOut','clockOutHint');
     log('Gamma calibration complete. Quitting expServer');
-    running = false;
+    % move PTB window to foreground
+    Screen(stimWindow, 'WindowShieldingLevel', 2000);
+    stimWindow.close();
+    stimWindow.open();
   end
 
   function saveGamma(cal)

--- a/+srv/expServer.m
+++ b/+srv/expServer.m
@@ -359,11 +359,13 @@ ShowCursor();
   function calibrateGamma()
     stimWindow = rig.stimWindow;
     DaqDev = rig.daqController.DaqIds;
-    lightIn = 'ai0'; % defaults from hw.psy.Window
-    clockIn = 'ai1';
-    clockOut = 'port1/line0 (PFI4)';
-    log(['Please connect photodiode to %s, clockIn to %s and clockOut to %s.\r'...
-        'Press any key to contiue\n'],lightIn,clockIn,clockOut);
+    lightIn = 'ai1'; % defaults from hw.psy.Window
+    clockIn = 'ai0';
+    clockOut = 'port1/line0';
+    clockOutHint = 'PFI4';
+    log(['Please connect photodiode to %s, clockIn to %s and clockOut to '... 
+        '%s (%s).\r Press any key to contiue\n'],...
+        lightIn,clockIn,clockOut, clockOutHint);
     pause; % wait for keypress
     stimWindow.Calibration = stimWindow.calibration(DaqDev); % calibration
     pause(1);

--- a/+srv/expServer.m
+++ b/+srv/expServer.m
@@ -373,7 +373,8 @@ ShowCursor();
     saveGamma(stimWindow.Calibration);
     stimWindow.applyCalibration(stimWindow.Calibration);
     clear('lightIn','clockIn','clockOut','clockOutHint');
-    log('Gamma calibration complete');
+    log('Gamma calibration complete. Quitting expServer');
+    running = false;
   end
 
   function saveGamma(cal)

--- a/cortexlab/+git/changes.m
+++ b/cortexlab/+git/changes.m
@@ -1,6 +1,0 @@
-disp('Updating queued Alyx posts...')
-posts = dirPlus(getOr(dat.paths, 'localAlyxQueue', 'C:/localAlyxQueue'));
-posts = posts(endsWith(posts, 'put'));
-newPosts = cellfun(@(str)[str(1:end-3) 'patch'], posts, 'uni', 0);
-status = cellfun(@movefile, posts, newPosts);
-assert(all(status), 'Unable to rename queued Alyx files, please do this manually')


### PR DESCRIPTION
Fixes for #4, #128, #164

If this type of fix looks good, let me know. I also want to improve the doc for hw.ptb.Window, make function/method names clearer, and create simple config scripts explaining how to run gamma calibration and reward valve calibration (these may share some redundancy with what goes on ReadTheDocs, but I think that's fine)