### PR TITLE
add informative error messages to water valve calibration code

### DIFF
--- a/+hw/WeighingScale.m
+++ b/+hw/WeighingScale.m
@@ -51,6 +51,7 @@ classdef WeighingScale < handle
             % Do nothing
         end
       end
+      obj.tare(); % Tare the scale to ensure LastGrams is never empty
     end
     
     function cleanup(obj)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@ Starting after Rigbox 2.2.0, this file contains a curated, chronologically order
 - Patch in alyx-matlab submodule 2019-07-25
 - updated Signals performance test `993d906` 2019-07-19
 - fixes to tests for the Alyx Panel `eb5e9b9` 2019-07-19
+- improvements to water expServer calibration function `dd0adb7` 2019-08-14
 
 ## [2.2.1](https://github.com/cortex-lab/Rigbox/releases/tag/v2.2.1) (Most Recent Stable Version)


### PR DESCRIPTION
Added some error messages to hw.calibrate to deal with the case that the scale isn't there or that it's not communicating properly. Also added 'tare' to the 'init' of weighingscale -- otherwise it was sometimes returning an empty reading.