### PR TITLE
Scale cleanup

### DIFF
--- a/+srv/StimulusControl.m
+++ b/+srv/StimulusControl.m
@@ -178,7 +178,7 @@ classdef StimulusControl < handle
     end
   end
   
-  methods %(Access = protected) %TODO Check everything works as protected
+  methods (Access = protected)
     function b = connected(obj)
       b = ~isempty(obj.Socket) && obj.Socket.isOpen();
     end
@@ -288,7 +288,7 @@ classdef StimulusControl < handle
   methods (Static)
     function errorOnFail(r)
       if iscell(r) && strcmp(r{1}, 'fail')
-        error(r{3});
+        error(r{3:end})
       end
     end
   end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Starting after Rigbox 2.2.0, this file contains a curated, chronologically ordered list of notable changes made to the master branch. Each bullet point in the list is followed by the accompanying commit hash, and the date of the commit. This changelog is based on [keep a changelog](https://keepachangelog.com)
 
-## [Most Recent Commits](https://github.com/cortex-lab/Rigbox/commits/master) 2.4.0
+## [Most Recent Commits](https://github.com/cortex-lab/Rigbox/commits/master) 2.4.1
 
 - patch to readme linking to most up-to-date documentation `4ff1a21` 2019-09-16
 - updates to `+git` package and its tests `5841dd6` 2019-09-24
@@ -18,6 +18,8 @@ Starting after Rigbox 2.2.0, this file contains a curated, chronologically order
 - better organization of expServer `f32a0fe` 2019-10-02
 - bug fix for rounding negative numbers in AlyxPanel `31641f1` 2019-10-17
 - stricter and more accurate tolerance in AlyxPanel_test `31641f1` 2019-10-17
+- HOTFIX to error when plotting supressed in Window calibrate `7d6b601` 2019-11-15
+- Added change scale port helper; fixed issue with scale cleanup on calibrate error `01e394b` 2019-11-27
 
 
 ## [2.3.0](https://github.com/cortex-lab/Rigbox/releases/tag/v2.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Starting after Rigbox 2.2.0, this file contains a curated, chronologically ordered list of notable changes made to the master branch. Each bullet point in the list is followed by the accompanying commit hash, and the date of the commit. This changelog is based on [keep a changelog](https://keepachangelog.com)
 
-## [Most Recent Commits](https://github.com/cortex-lab/Rigbox/commits/master) 2.4.1
+## [Most Recent Commits](https://github.com/cortex-lab/Rigbox/commits/master) 2.5.0
+
+- Added change scale port helper; fixed issue with scale cleanup on calibrate error `01e394b` 2019-11-27
+- Added support for remote error ids in srv.StimulusControl `9d31eea` 2019-11-27
+
+
+## [2.4.1]
 
 - patch to readme linking to most up-to-date documentation `4ff1a21` 2019-09-16
 - updates to `+git` package and its tests `5841dd6` 2019-09-24
@@ -19,8 +25,6 @@ Starting after Rigbox 2.2.0, this file contains a curated, chronologically order
 - bug fix for rounding negative numbers in AlyxPanel `31641f1` 2019-10-17
 - stricter and more accurate tolerance in AlyxPanel_test `31641f1` 2019-10-17
 - HOTFIX to error when plotting supressed in Window calibrate `7d6b601` 2019-11-15
-- Added change scale port helper; fixed issue with scale cleanup on calibrate error `01e394b` 2019-11-27
-
 
 ## [2.3.0](https://github.com/cortex-lab/Rigbox/releases/tag/v2.3.0)
 

--- a/cortexlab/+hw/setScalePort.m
+++ b/cortexlab/+hw/setScalePort.m
@@ -1,0 +1,24 @@
+function scale = setScalePort(port, rigname)
+% CHANGESCALEPORT Set the port of the scale in the hardware object
+%  Sets the COM port of the scale and saves it into the hardware file.
+%  
+%  Inputs:
+%    port (char|numerical) : which port to set the hardware scale to
+%    rigname (char) : the host name of the rig whose scale port to change
+%  
+%  Output:
+%    scale (hw.WeighingScale) : the edited scale object
+%
+%  Examples:
+%    scale = setScalePort('COM3')
+%    setScalePort(3, 'ZREDONE')
+% 
+% See also HW.DEVICES
+if nargin < 2
+  rigname = upper(hostname);
+end
+
+hwPath = fullfile(getOr(dat.paths,'globalConfig'),rigname,'hardware.mat');
+load(hwPath, 'scale')
+scale.ComPort = iff(upper(port(1)) == 'C', upper(port), ['COM',num2str(port)]);
+save(hwPath, 'scale', '-append')

--- a/tests/Contents.m
+++ b/tests/Contents.m
@@ -6,35 +6,38 @@
 %  check the coverage of a given test, use `checkCoverage`.
 % 
 % Files:
-%   runall            - gathers and runs all tests in Rigbox
-%   checkCoverage     - Check the coverage of a given test
-%   AlyxPanel_test    - Tests for eui.AlyxPanel
-%   ParamEditor_test  - Tests for eui.ParamEditor
-%   Parameters_test   - Tests for exp.Parameters
-%   calibrate_test    - Tests for hw.calibrate
-%   catStructs_test   - Tests for catStructs
-%   cellflat_test     - Tests for cellflat
-%   cellsprintf_test  - Tests for cellsprintf
-%   dat_test          - Tests for the +dat package
-%   emptyElems_test   - Tests for emptyElems
-%   ensureCell_test   - Tests for ensureCell
-%   expServer_test    - Tests for srv.expServer
-%   fileFunction_test - Tests for fileFunction
-%   file_test         - Tests for the +file package
-%   fun_test          - Tests for the +fun package
-%   iff_test          - Tests for iff
-%   inferParams_test  - inferParams test
-%   loadVar_test      - loadVar test
-%   mapToCell_test    - Tests for mapToCell function
-%   mergeStructs_test - mergeStructs test
-%   namedArg_test     - namedArg test
-%   nop_test          - Tests for nop
-%   num2cellstr_test  - Tests for num2cellstr
-%   obj2json_test     - Tests for obj2struct
-%   pick_test         - pick test
-%   repelems_test     - repelems test
-%   structAssign_test - structAssign test
-%   superSave_test    - superSave test
-%   tabulateArgs_test - Tests for tabulateArgs
-%   varName_test      - varName test
+%   runall               - gathers and runs all tests in Rigbox
+%   checkCoverage        - Check the coverage of a given test
+%   AlyxPanel_test       - Tests for eui.AlyxPanel
+%   ParamEditor_test     - Tests for eui.ParamEditor
+%   Parameters_test      - Tests for exp.Parameters
+%   StimulusControl_test - Tests for srv.StimulusControl and
+%                          srv.stimulusControllers
+%   calibrate_test       - Tests for hw.calibrate
+%   catStructs_test      - Tests for catStructs
+%   cellflat_test        - Tests for cellflat
+%   cellsprintf_test     - Tests for cellsprintf
+%   dat_test             - Tests for the +dat package
+%   emptyElems_test      - Tests for emptyElems
+%   ensureCell_test      - Tests for ensureCell
+%   expServer_test       - Tests for srv.expServer
+%   fileFunction_test    - Tests for fileFunction
+%   file_test            - Tests for the +file package
+%   fun_test             - Tests for the +fun package
+%   iff_test             - Tests for iff
+%   inferParams_test     - inferParams test
+%   loadVar_test         - loadVar test
+%   mapToCell_test       - Tests for mapToCell function
+%   mergeStructs_test    - mergeStructs test
+%   namedArg_test        - namedArg test
+%   nop_test             - Tests for nop
+%   num2cellstr_test     - Tests for num2cellstr
+%   obj2json_test        - Tests for obj2struct
+%   pick_test            - pick test
+%   repelems_test        - repelems test
+%   structAssign_test    - structAssign test
+%   superSave_test       - superSave test
+%   tabulateArgs_test    - Tests for tabulateArgs
+%   varName_test         - varName test
+
 

--- a/tests/StimulusControl_test.m
+++ b/tests/StimulusControl_test.m
@@ -1,0 +1,106 @@
+%STIMULUSCONTROL_TEST Tests for srv.StimulusControl and
+%srv.stimulusControllers
+%  TODO Create tests for remaining methods
+classdef (SharedTestFixtures={ % add 'fixtures' folder as test fixture
+    matlab.unittest.fixtures.PathFixture('fixtures'),...
+    matlab.unittest.fixtures.PathFixture(['fixtures' filesep 'util'])})...
+    StimulusControl_test < matlab.unittest.TestCase & matlab.mock.TestCase
+  
+  properties (SetAccess = protected)
+    % An experiment reference for the test
+    Ref
+    % A list of StimulusControl names for testing the remote file
+    RemoteNames = {'Rig1', 'Sevvan', 'Reet'}
+  end
+  
+  methods (TestClassSetup)
+    function setupFolder(testCase)
+      % SETUPFOLDER Set up subject, queue and config folders for test
+      %  Creates a few folders for saving parameters and hardware.  Adds
+      %  teardowns for deletion of these folders.  Also creates a custom
+      %  paths file to deactivate Alyx.
+      %
+      % TODO Make into shared fixture
+      
+      assert(endsWith(which('dat.paths'),...
+        fullfile('tests', 'fixtures', '+dat', 'paths.m')));
+      
+      % Set INTEST flag to true
+      testCase.setTestFlag(true)
+      testCase.addTeardown(@testCase.setTestFlag, false)
+
+      % Create a rig config folder
+      configDir = getOr(dat.paths, 'rigConfig');
+      assert(mkdir(configDir), 'Failed to create config directory')
+      
+      % Clear loadVar cache
+      addTeardown(testCase, @clearCBToolsCache)
+      
+      % Create a remote file for one of the tests
+      globalConfigDir = getOr(dat.paths, 'globalConfig');
+      stimulusControllers = cellfun(@srv.StimulusControl.create, testCase.RemoteNames);
+      save(fullfile(globalConfigDir, 'remote'), 'stimulusControllers')
+      assert(file.exists(fullfile(globalConfigDir, 'remote.mat')))
+      
+      % Add teardown to remove folders
+      rmFcn = @()assert(rmdir(globalConfigDir, 's'), ...
+        'Failed to remove test config folder');
+      addTeardown(testCase, rmFcn)
+      
+      % Set some default behaviours for some of the objects; create a ref
+      testCase.Ref = dat.constructExpRef('test', now, randi(10000));
+    end
+    
+  end
+    
+  methods (Test)
+    
+    function test_create(testCase)
+      % Test for constructor defaults
+      name = testCase.RemoteNames{1};
+      sc = srv.StimulusControl.create(name);
+      testCase.verifyMatches(sc.Name, name, 'Failed to set Name')
+      testCase.verifyMatches(sc.Uri, ['.*',name,':',num2str(sc.DefaultPort)])
+      
+      uri = 'ws://rig:1428';
+      sc = srv.StimulusControl.create(name, uri);
+      testCase.verifyMatches(sc.Name, name, 'Failed to set Name')
+      testCase.verifyEqual(sc.Uri, uri, 'Failed to set provided uri')
+    end
+    
+    function test_errorOnFail(testCase)
+      % A message array to test
+      id = 'test:error:failSent';
+      msg = 'Fail message';
+      r = {'success', testCase.Ref, id, msg};
+      
+      srv.StimulusControl.errorOnFail('This is no error') % Test char input
+      srv.StimulusControl.errorOnFail(r) % Test array input without fail
+      r{1} = 'fail'; % Change message to fail state
+      testCase.verifyError(@()srv.StimulusControl.errorOnFail(r), id, ...
+        'Failed to throw error with ID')
+      ex.message = [];
+      r(3) = []; % Remove ID
+      try srv.StimulusControl.errorOnFail(r), catch ex, end
+      testCase.verifyMatches(ex.message, msg, 'Failed to throw error without ID')
+    end
+    
+    function test_stimulusControllers(testCase)
+      % Test the loading of saved StimulusControl objects via dat.paths
+      sc = srv.stimulusControllers;
+      testCase.verifyLength(sc, length(testCase.RemoteNames))
+      testCase.verifyTrue(isa(sc, 'srv.StimulusControl'))
+      testCase.verifyEqual({sc.Name}, sort(testCase.RemoteNames), ...
+        'Failed to return array sorted by Name')
+    end
+  end
+  
+  methods (Static)
+    function setTestFlag(TF)
+      % SETTESTFLAG Set global INTEST flag
+      %   Allows setting of test flag via callback function
+      global INTEST
+      INTEST = TF;
+    end
+  end
+end

--- a/tests/expServer_test.m
+++ b/tests/expServer_test.m
@@ -224,7 +224,7 @@ classdef (SharedTestFixtures={ % add 'fixtures' folder as test fixture
     function test_devices_fail(testCase)
       % Set hw.devices to return empty
       clear devices;
-      id = 'rigbox:srv:expServer:missingHardware';
+      id = 'Rigbox:srv:expServer:missingHardware';
       testCase.verifyError(@srv.expServer, id, ...
         'Expected error for misconfigured hardware');
     end


### PR DESCRIPTION
- Fix for #219 
- Support for remote error message ids in srv.StimulusControl
- Added a convenience function for setting a scale port in the hardware file
- Returned access restriction (#122)