### PR TITLE
String support for git.update

### DIFF
--- a/cortexlab/+git/update.m
+++ b/cortexlab/+git/update.m
@@ -10,22 +10,25 @@ function exitCode = update(scheduled)
 %   (provided the remote code was last fetched over an hour ago).
 %   
 %   Inputs:
-%     `scheduled`: an optional input as an integer in the interval [0,7]. 
-%     When 0, the remote code will be pulled provided the last fetch was 
-%     over an hour ago. When in the interval [1,7], code will be pulled on 
-%     a corresponding day according to `weekday` (Sunday=1, Monday=2, ... 
-%     Saturday = 7), provided the last fetch was over a day ago. Code will 
-%     also be pulled if it is not the scheduled day, but the last fetch was 
-%     over a week ago. If scheduled is 0, the function will pull changes 
-%     provided the last fetch was over an hour ago.
+%     scheduled (int|string|char|cellstr): an optional input as an
+%       integer in the interval [-1,7]. When -1 or 'Never', code is never
+%       updated. When 0 or 'Everyday', the remote code will be pulled
+%       provided the last fetch was over an hour ago. When in the interval
+%       [1,7], code will be pulled on a corresponding day according to
+%     weekday (Sunday=1, Monday=2, ... Saturday = 7), provided the last
+%       fetch was over a day ago. Code will also be pulled if it is not the
+%       scheduled day, but the last fetch was over a week ago. If scheduled
+%       is 0, the function will pull changes provided the last fetch was
+%       over an hour ago.  Input may also be string-type input and/or an
+%       array if multiple update days are required.
 %
 %   Outputs:
-%     `exitCode`: An integer in the interval [0,2]. 0 indicates a
-%     successful update of the code. 1 indicates an error running git
-%     commands. 2 indicates successfully returning from the function
-%     without updating the code if the last fetch was within an hour and
-%     `scheduled` == 0, or if the last fetch was within 24 hours and
-%     `scheduled` is an integer in the interval [1,7]).
+%     exitCode: An integer in the interval [0,2]. 0 indicates a
+%       successful update of the code. 1 indicates an error running git
+%       commands. 2 indicates successfully returning from the function
+%       without updating the code if the last fetch was within an hour and
+%       `scheduled` == 0, or if the last fetch was within 24 hours and
+%       `scheduled` is an integer in the interval [1,7]).
 %
 %   Example: Pull remote code immediately, provided last code fetch was 
 %   over an hour ago:
@@ -34,6 +37,10 @@ function exitCode = update(scheduled)
 %   Example: Pull remote code if today is Monday, provided last code fetch
 %   was over a day ago:
 %     git.update(2);
+% 
+%   Example: Pull remote code if today is Wednesday or Friday, provided
+%   last code fetch was over a day ago:
+%     git.update(["Wednesday", "fri"]);
 % 
 % See also DAT.PATHS
 
@@ -47,12 +54,24 @@ assert(~isempty(which('dat.paths')), ...
 % If no input arg, or input arg is not an acceptable value, use 
 % `updateSchedule` in `dat.paths`. If `updateSchedule` is not found, set 
 % `scheduled` to 0.
-if nargin < 1
-  scheduled = getOr(dat.paths, 'updateSchedule', 0);
-elseif ~isnumeric(scheduled) || ~any(0:7 == scheduled)
+if nargin < 1, scheduled = getOr(dat.paths, 'updateSchedule', 0); end
+
+% Validate input.  Must be a number between -1 and 7, or a string/char that
+% matches one of the below days, e.g. 'Mon' or ["Tuesday", "thursday"]
+if isstring(scheduled) || ischar(scheduled) || iscellstr(scheduled)
+  nameMap = [...
+    "Never", "Everyday", "Sunday", ...
+    "Monday", "Tuesday", "Wednesday", ...
+    "Thursday", "Friday", "Saturday"];
+  idx = startsWith(nameMap, scheduled, 'IgnoreCase', true);
+  assert(any(idx), 'Rigbox:git:update:valueError', ...
+    'Unrecognized scheduled value')
+  scheduled = find(idx) - 2; % Convert to day number
+elseif ~isnumeric(scheduled) || ~any(ismember(scheduled, -1:7))
     error('Rigbox:git:update:valueError', ...
         'Input must be integer between 0 and 7')
 end
+
 root = getOr(dat.paths, 'rigbox'); % Rigbox root directory
 
 % Attempt to find date of last fetch
@@ -66,8 +85,8 @@ lastFetch = iff(exist(fetch_head,'file')==2, ...
 % 1. The last fetch was over a week ago.
 % 2. The updates are scheduled for today and not yet fetched today.
 % 3. The updates are daily and the last fetch was over an hour ago.
-fetchDay = scheduled == weekday(now) || scheduled == false;
-minTime = iff(scheduled, iff(fetchDay, 1, 7), 1/24);
+fetchDay = any(scheduled == weekday(now)) || any(scheduled == 0);
+minTime = iff(scheduled ~= 0, iff(fetchDay, 1, 7), 1/24);
 fetched = now-lastFetch < minTime;
 if fetched || ~fetchDay
   exitCode = 2;

--- a/docs/setup/paths_template.m
+++ b/docs/setup/paths_template.m
@@ -52,8 +52,9 @@ p.databaseURL = 'https://alyx.cortexlab.net';
 p.localAlyxQueue = 'C:\localAlyxQueue'; % Location of cached posts
 % Location of git for automatic updates
 p.gitExe = 'C:\Program Files\Git\cmd\git.exe'; 
-% Day on which to update code (0 = Everyday, 1 = Sunday, etc.)
-p.updateSchedule = 0;
+% Day on which to update code (0 = Everyday, 1 = Sunday, etc.)  See
+% GIT.UPDATE for mor details.
+p.updateSchedule = 'Monday';
 
 % Alternate file repository: unlike alternates defined with a number (e.g.
 % 'main2Repository'), 'altRepository' is returned as an alternate to every

--- a/tests/cortexlab/setScalePort_test.m
+++ b/tests/cortexlab/setScalePort_test.m
@@ -27,7 +27,7 @@ classdef (SharedTestFixtures={ % add 'fixtures' folder as test fixture
         save(fullfile(hwPaths{i}, 'hardware'), 'scale');
       end
       
-      addTeardown(testCase, @ClearTestCache) % Remove folders on teardown
+      testCase.applyFixture(ClearTestCache) % Remove folders on teardown
     end
   end
   

--- a/tests/expServer_test.m
+++ b/tests/expServer_test.m
@@ -46,7 +46,12 @@ classdef (SharedTestFixtures={ % add 'fixtures' folder as test fixture
       qDir = getOr(dat.paths, 'localAlyxQueue');
       assert(mkdir(qDir), 'Failed to create alyx queue')
       
-      addTeardown(testCase, @ClearTestCache)
+      % Supress warnings for file.modeDate mock, called by git.update
+      orig = warning('off', 'Rigbox:tests:modDate:dateNotSet');
+      addTeardown(testCase, @warning, orig)
+      
+      % Clear all cached and persistant variables at the end
+      testCase.applyFixture(ClearTestCache)
     end
     
   end

--- a/tests/expServer_test.m
+++ b/tests/expServer_test.m
@@ -49,18 +49,6 @@ classdef (SharedTestFixtures={ % add 'fixtures' folder as test fixture
       addTeardown(testCase, @ClearTestCache)
     end
     
-    function fixUpdates(~)
-      % FIXUPDATES Ensure git update doesn't pull code
-      %  Have FETCH_HEAD file appear recently modified to avoid triggering
-      %  any code updates.
-      %
-      % See also GIT.UPDATE
-      
-      % Make sure git update not triggered
-      root = getOr(dat.paths, 'rigbox'); % Rigbox root directory
-      fetch_head = fullfile(root, '.git', 'FETCH_HEAD');
-      file.modDate(fetch_head, now); % Set recent fetch
-    end
   end
   
   methods (TestMethodSetup)

--- a/tests/fixtures/+dat/paths.m
+++ b/tests/fixtures/+dat/paths.m
@@ -27,7 +27,7 @@ p.localRepository = fullfile(p.rigbox, 'tests', 'fixtures', 'local');
 p.localAlyxQueue = fullfile(p.rigbox, 'tests', 'fixtures', 'alyxQ');
 p.databaseURL = 'https://test.alyx.internationalbrainlab.org';
 p.gitExe = 'C:\Program Files\Git\cmd\git.exe';
-p.updateSchedule = weekday(now)+1; % Always tomorrow
+p.updateSchedule = -1; % Never pull code
 
 % Under the new system of having data grouped by mouse
 % rather than data type, all experimental data are saved here.


### PR DESCRIPTION
Changes:
1. Template now has update set for Monday.
2. Never flag now implemented (code -1)
3. String-type inputs are supported, e.g. `'monday'`, `"Mon"`, `{'Everyday'}`
4. Arrays supported, e.g. `[3, 6]`, `["Tue", "Fri"]`
5. Updated tests
