### PR TITLE
Add method for installing Rigbox to use the Alyx Panel but nothing else

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ git clone --recurse-submodules https://github.com/cortex-lab/Rigbox
 `addRigboxPaths()`, OR `addRigboxPaths('SavePaths', false)` if you don't want to save the paths for future MATLAB sessions. 
 (*Note*: Do **not** manually add all Rigbox folders and subfolders to the paths.)
 
+### Lightweight Install of Alyx Panel only
+
+Rigbox is also useful for communicating with the Alyx database directly using a MATLAB GUI that can be opened with: ``eui.AlyxPanel();``. This GUI has fewer requirements than the full Rigbox package, and you may want to install Rigbox for this purpose only (for example, on a computer designated for mouse work and handling). To install Rigbox via Git for this minimum capacity functionality, follow the following instructions:
+
+1. In your git terminal, run:
+```
+git clone --recurse-submodules https://github.com/cortex-lab/Rigbox
+```
+
+2. In MATLAB, navigate to the Rigbox root directory (where Rigbox was cloned), and run: `enableAlyxPanel()`, OR `enableAlyxPanel('SavePaths', false)` if you don't want to save the paths for future MATLAB sessions. (*Note*: Do **not** manually add all Rigbox folders and subfolders to the paths.)
+
+3. You will also have to make sure that the GUI Layout Toolbox is installed from the MATLAB Add-Ons menu and that the ``dat.paths`` file includes the correct url to the Alyx database. 
+
 ## Getting started
 
 To ensure the installation completed successfully, try running the [example experiments from the Rigbox paper](https://cortex-lab.github.io/Rigbox/paper_examples.html).

--- a/enableAlyxPanel.m
+++ b/enableAlyxPanel.m
@@ -1,0 +1,78 @@
+function enableAlyxPanel(varargin)
+%enableAlyxPanel Adds the required paths for using the AlyxPanel
+%  enableAlyxPanel([savePaths, strict]) or 
+%  enableAlyxPanel('SavePaths', true, 'Strict', true)
+%
+%   Inputs (Optional):
+%     savePaths (logical): If true, added paths are saved between sessions
+%     strict (logical): Assert toolbox & system requirements are all met
+%
+% Part of the Rigging toolbox
+%
+% 2014-01 CB
+% 2017-02 MW Updated to work with 2016b
+% 2024-03 ATL Added to enable AlyxPanel use only without other features
+
+%%% Input validation %%%
+% Allow positional or Name-Value pairs
+p = inputParser;
+p.addOptional('savePaths', true)
+p.addOptional('strict', true)
+p.parse(varargin{:});
+p = p.Results;
+
+%%% MATLAB version and toolbox validation %%%
+toolboxes = ver;
+  
+if p.strict
+  % MATLAB must be running on Windows
+  assert(ispc, 'Rigbox currently only works on Windows 10')
+  
+  % Check MATLAB 2018b is running
+  assert(~verLessThan('matlab', '9.5'), 'Requires MATLAB 2018b or later')
+  
+  % Check that GUI Layout Toolbox is installed (required for the master
+  % computer only)
+  isInstalled = strcmp('GUI Layout Toolbox', {toolboxes.Name});
+  if ~any(isInstalled) ||...
+      str2double(erase(toolboxes(isInstalled).Version,'.')) < 230
+    warning('Rigbox:setup:toolboxRequired',...
+      ['MC requires GUI Layout Toolbox v2.3 or higher to be installed.'...
+       ' Click <a href="matlab:web(''%s'',''-browser'')">here</a> to' ...
+       ' install.'], ['https://uk.mathworks.com/matlabcentral/fileexchange'...
+       '/47982-gui-layout-toolbox'])
+  end
+end
+
+%%% Add paths %%%
+% Add the main Rigbox directory, containing the main packages for running
+% the experiment server and mc
+root = fileparts(mfilename('fullpath')); 
+addpath(root);
+
+% The cb-tools directory contains numerious convenience functions which are
+% utilized by the main code. Those within the 'burgbox' directory were
+% written by Chris Burgess.  
+addpath(fullfile(root, 'cb-tools', 'burgbox')); 
+
+% Add the paths for Alyx-matlab. This submodule allows one to interact
+% with an instance of an Alyx database. For more information please visit:
+% http://alyx.readthedocs.io/en/latest/
+addpath(fullfile(root, 'alyx-matlab'), fullfile(root, 'alyx-matlab', 'helpers'));
+
+%%% Remind user to copy paths file %%%
+if ~exist('+dat/paths','file')
+  template_paths = fullfile(root, 'docs', 'scripts', 'paths_template.m');
+  new_loc = fullfile(root, '+dat', 'paths.m');
+  copied = copyfile(template_paths, new_loc);
+  % Check that the file was copied
+  if ~copied
+    warning('Rigbox:setup:copyPaths', 'Please copy the file ''%s'' to ''%s''.',...
+      template_paths, new_loc);
+  end
+end
+
+%%% Validate that paths saved correctly %%%
+if p.savePaths
+  assert(savepath == 0, 'Failed to save changes to MATLAB path');
+end


### PR DESCRIPTION
The only thing this needed was a lightweight "addPaths" file as an alternative to ``addRigboxPaths``, which I called ``enableAlyxPanel``. It acts the same way, but removes everything that is unnecessary for the AlyxPanel. 

I also added some instructions in the README for how to do this and why you'd want to. 