### PR TITLE
handle failure to connect to server in intelligent way

### DIFF
--- a/+eui/AlyxPanel.m
+++ b/+eui/AlyxPanel.m
@@ -277,9 +277,16 @@ classdef AlyxPanel < handle
                     for fts = 1:length(firstTimeSubs)
                         thisDir = fullfile(dat.reposPath('main', 'master'), firstTimeSubs{fts});
                         if ~exist(thisDir, 'dir')
-                            fprintf(1, 'making directory for %s\n', firstTimeSubs{fts});
-                            mkdir(thisDir);
-                        end
+                            try
+                                mkdir(thisDir);
+                                fprintf(1, 'made directory for %s\n', firstTimeSubs{fts});
+                            catch ex
+                                fprintf(2, "login was successful, but failed to connect to: %s.\n", dat.reposPath('main', 'master'));
+                                fprintf(2, "due to the following error: %s", ex.message)
+                                fprintf(2, "logging out.\n")
+                                obj.login()
+                            end
+                        end 
                     end
                 elseif obj.AlyxInstance.Headless
                     % Panel inactive or login failed due to Alyx being down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file contains a curated, chronologically ordered list of notable changes ma
 
 - HOTFIX: Alyx-MATLAB update
 - HOTFIX: Corrected typo in obj2struct
+- Improved behavior of AlyxPanel when login to data server fails (informative error message, automatic logout)
 
 ## [2.6.4]
 


### PR DESCRIPTION
Before, if the computer was not logged into the server, an error message would show up about the username/password (but not emphasize that it was due to the server -- not the alyx database), and the rest of the login function would fail, so the AlyxPanel GUI wouldn't finish updating to reflect the login. 

With this PR, it will send an informative error message and logout. 